### PR TITLE
PRでもCIが動作するようにする・Node.jsのバージョン変更

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
     branches:
     - 'master'
     - 'release'
+  pull_request:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup NodeJs
       uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: '16.x'
     - name: Cache node_modules
       uses: actions/cache@preview
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup NodeJs
       uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '14.x'
     - name: Cache node_modules
       uses: actions/cache@preview
       with:


### PR DESCRIPTION
PRでもCIが動作するようにします。
また、CIが失敗しないようNode.jsのバージョンを変更します。

https://github.com/cloudlatex-team/cloudlatex-cli-plugin/runs/4997831446?check_suite_focus=true

```
error node-fetch@3.1.1: The engine "node" is incompatible with this module. Expected version "^12.20.0 || ^14.13.1 || >=16.0.0". Got "10.24.1"
```