### PR TITLE
CI: Actionsアップデート

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup NodeJs
-      uses: actions/setup-node@v2.5.1
+      uses: actions/setup-node@v4
       with:
         node-version: '14.x'
         cache: yarn


### PR DESCRIPTION
https://github.com/cloudlatex-team/cloudlatex-cli-plugin/actions/runs/6754790666

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-node@v2.5.1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

```
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

GitHub Actionsにおいて、node 12や `set-state`, `set-output` は非推奨なので、Actionsをアップデートします。