### PR TITLE
CI: PRで二重に動作しないようにする

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ name: build
 # events but only for the master branch
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
CIがPRで二重に動作しているので、pushトリガーはmainブランチのみで動作するようにします。