### PR TITLE
fix: correct spelling errors throughout the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cloudlatex-cli --path ./  \
 
 
 Then, your project files will be downloaded.
-Local file changes will synchronized with the Cloud LaTeX server and compilation is fired on the server.
+Local file changes will be synchronized with the Cloud LaTeX server and compilation is fired on the server.
 
 After the second time, run the same command as before.
 

--- a/src/backend/cloudlatex/clBackend.ts
+++ b/src/backend/cloudlatex/clBackend.ts
@@ -34,7 +34,7 @@ export class ClBackend implements IBackend {
      */
     if (file.url[0] === '/') {
       const fileUrl = url.resolve(url.resolve(this.config.endpoint, '..'), file.url);
-      return this.api.downdloadPreview(fileUrl);
+      return this.api.downloadPreview(fileUrl);
     }
 
     return this.api.download(file.url);

--- a/src/backend/cloudlatex/webAppApi.ts
+++ b/src/backend/cloudlatex/webAppApi.ts
@@ -200,7 +200,7 @@ export class CLWebAppApi {
     return res.body;
   }
 
-  async downdloadPreview(url: string): Promise<NodeJS.ReadableStream> {
+  async downloadPreview(url: string): Promise<NodeJS.ReadableStream> {
     const res = await fetch(url, this.fetchOption());
     if (!res.body) {
       throw new Error('res.body is null');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@
 import { LatexApp } from './latexApp';
 import { Config, ProjectInfo, AppInfo, ConflictSolution } from './types';
 
-// TDOO
+// TODO
 function main() {
   console.log('cli module is not currently supported');
   return;

--- a/src/fileService/filePath.ts
+++ b/src/fileService/filePath.ts
@@ -39,8 +39,8 @@ const DEFAULT_USER_IGNORED_FILES = [
 
 export const dotFileExceptLatexmkrc = '**/.!(latexmkrc)';
 
-function mergeMatcher(...macthers: Matcher[]): Matcher {
-  return macthers.reduce<Matcher & Array<unknown>>((merged, matcher) => {
+function mergeMatcher(...matchers: Matcher[]): Matcher {
+  return matchers.reduce<Matcher & Array<unknown>>((merged, matcher) => {
     if (Array.isArray(matcher)) {
       merged.push(...matcher);
     } else {
@@ -67,7 +67,7 @@ function calcIgnoredFilesByConfig(userIgnoredFiles?: Matcher): Matcher {
   }
 }
 
-// Absoulte path pattern
+// Absolute path pattern
 function calcIgnoredFilesByArtifacts(appInfoService: AppInfoService): Matcher {
   return (absPath) => [
     appInfoService.appInfo.logPath,
@@ -76,7 +76,7 @@ function calcIgnoredFilesByArtifacts(appInfoService: AppInfoService): Matcher {
   ].includes(toRelativePath(appInfoService.config, absPath));
 }
 
-// Absoulte path pattern
+// Absolute path pattern
 export function calcIgnoredFiles(appInfoService: AppInfoService): Matcher {
   return mergeMatcher(
     calcIgnoredFilesByConfig(appInfoService.config.ignoredFiles),

--- a/src/latexApp.ts
+++ b/src/latexApp.ts
@@ -112,8 +112,8 @@ export class LatexApp extends LAEventEmitter implements ILatexApp {
    *
    * Instantiate fileAdapter, fileWatcher and syncManager.
    * The fileWatcher detects local changes.
-   * The syncManager synchronize local files with remote ones.
-   * The file Adapter abstructs file operations of local files and remote ones.
+   * The syncManager synchronizes local files with remote ones.
+   * The file Adapter abstracts file operations of local files and remote ones.
    */
   static async createApp(config: Config, option: {
     logger?: Logger,
@@ -153,7 +153,7 @@ export class LatexApp extends LAEventEmitter implements ILatexApp {
     const syncRepo = db.getRepository(SYNC_DESC);
     if (dbLoaded) {
       if (syncRepo.all().length === 0) {
-        // Previously synced but record is not crated
+        // Previously synced but record is not created
         logger.info('Previously synced but record is not created');
         syncRepo.new({ synced: true });
       }

--- a/src/service/accountService.ts
+++ b/src/service/accountService.ts
@@ -8,7 +8,7 @@ export class AccountService<Account> {
   }
 
   /**
-   * save account (if savePath is undefined, only stored on memmory)
+   * save account (if savePath is undefined, only stored on memory)
    *
    * @param account account to save
    */

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -9,44 +9,44 @@ const level2Number = {
 export class Logger {
   constructor(public logLevel: 'log' | 'info' | 'warn' | 'error' | 'silent' = 'log') {
   }
-  log(message: unknown, ...optinalParams: unknown[]): void {
+  log(message: unknown, ...optionalParams: unknown[]): void {
     if (level2Number[this.logLevel] <= level2Number.log) {
-      this._log(message, ...optinalParams);
+      this._log(message, ...optionalParams);
     }
   }
 
-  _log(message: unknown, ...optinalParams: unknown[]): void {
-    console.log(message, ...optinalParams);
+  _log(message: unknown, ...optionalParams: unknown[]): void {
+    console.log(message, ...optionalParams);
   }
 
-  info(message: unknown, ...optinalParams: unknown[]): void {
+  info(message: unknown, ...optionalParams: unknown[]): void {
     if (level2Number[this.logLevel] <= level2Number.info) {
-      this._info(message, ...optinalParams);
+      this._info(message, ...optionalParams);
     }
   }
 
-  _info(message: unknown, ...optinalParams: unknown[]): void {
-    console.info(message, ...optinalParams);
+  _info(message: unknown, ...optionalParams: unknown[]): void {
+    console.info(message, ...optionalParams);
   }
 
-  warn(message: unknown, ...optinalParams: unknown[]): void {
+  warn(message: unknown, ...optionalParams: unknown[]): void {
     if (level2Number[this.logLevel] <= level2Number.warn) {
-      this._warn(message, ...optinalParams);
+      this._warn(message, ...optionalParams);
     }
   }
 
-  _warn(message: unknown, ...optinalParams: unknown[]): void {
-    console.warn(message, ...optinalParams);
+  _warn(message: unknown, ...optionalParams: unknown[]): void {
+    console.warn(message, ...optionalParams);
   }
 
-  error(message: unknown, ...optinalParams: unknown[]): void {
+  error(message: unknown, ...optionalParams: unknown[]): void {
     if (level2Number[this.logLevel] <= level2Number.error) {
-      this._error(message, ...optinalParams);
+      this._error(message, ...optionalParams);
     }
   }
 
-  _error(message: unknown, ...optinalParams: unknown[]): void {
-    console.error(message, ...optinalParams);
+  _error(message: unknown, ...optionalParams: unknown[]): void {
+    console.error(message, ...optionalParams);
   }
 }
 

--- a/test/integ/fileManage.test.ts
+++ b/test/integ/fileManage.test.ts
@@ -128,7 +128,7 @@ class TestSituation {
       syncResult = await this.instances.syncManager.sync(this.config.conflictSolution);
     }
 
-    // Verify syncronization result
+    // Verify synchronization result
     await this.verify(syncResult);
   }
 

--- a/test/tool/syncTestTool.ts
+++ b/test/tool/syncTestTool.ts
@@ -40,7 +40,7 @@ export const TEST_CONFIG_LIST = (() => {
               describe += `conflictSolution: "${conflictSolution || 'unspecified'}" `;
             }
 
-            describe += `netowork: ${networkMode}`;
+            describe += `network: ${networkMode}`;
             list.push({
               changeStates: {
                 local,


### PR DESCRIPTION
## 概要
このPRは、コードベース全体で見つかった複数のスペルミスを修正します。

## 変更内容
以下のスペルミスを修正しました：

### コメント・ドキュメント
- `TDOO` → `TODO` (cli.ts)
- `abstructs` → `abstracts` (latexApp.ts)
- `crated` → `created` (latexApp.ts)
- `syncronization` → `synchronization` (fileManage.test.ts)
- `memmory` → `memory` (accountService.ts)
- `Absoulte` → `Absolute` (filePath.ts - 2箇所)
- `will synchronized` → `will be synchronized` (README.md - 文法修正)

### 変数名・パラメータ名
- `macthers` → `matchers` (filePath.ts)
- `optinalParams` → `optionalParams` (logger.ts - 16箇所)
- `netowork` → `network` (syncTestTool.ts)

### 関数名
- `downdloadPreview` → `downloadPreview` (webAppApi.ts, clBackend.ts)

## 影響範囲
- すべての変更は非機能的な修正（スペルミス・タイプミス修正）です
- 既存の機能に影響はありません
- コードの可読性とメンテナビリティが向上します

## テスト
- 既存のテストが引き続き動作することを確認しました