### PR TITLE
Use /files/:id/download endpoint instead of file_url

### DIFF
--- a/src/backend/cloudlatex/clBackend.ts
+++ b/src/backend/cloudlatex/clBackend.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import * as url from 'url';
 import * as pako from 'pako';
 import { TextDecoder } from 'text-encoding';
 
@@ -24,20 +23,11 @@ export class ClBackend implements IBackend {
   }
 
   public download(file: FileInfo): Promise<NodeJS.ReadableStream> {
-    /**
-     * TODO use `api/projects/[projectId]/files/[fileId]/download` endpoint
-     */
-
-    /*
-     * url of some files such as pdf begins with '/'
-     *    like '/projects/180901/files/1811770/preview'
-     */
-    if (file.url[0] === '/') {
-      const fileUrl = url.resolve(url.resolve(this.config.endpoint, '..'), file.url);
-      return this.api.downloadPreview(fileUrl);
+    // Use /files/:id/download endpoint instead of presigned URL
+    if (file.remoteId === null) {
+      throw new Error('remoteId is null');
     }
-
-    return this.api.download(file.url);
+    return this.api.downloadFile(Number(file.remoteId));
   }
 
   public async upload(
@@ -114,7 +104,7 @@ export class ClBackend implements IBackend {
         id: -1,
         isFolder: !!materialFile.is_folder,
         relativePath: String(materialFile.full_path),
-        url: String(materialFile.file_url),
+        url: '',  // No longer used, keeping for backward compatibility
         remoteRevision: materialFile.revision,
         localRevision: materialFile.revision,
         localChange: 'no',

--- a/src/backend/cloudlatex/types.ts
+++ b/src/backend/cloudlatex/types.ts
@@ -8,7 +8,6 @@ export interface ClFile {
   mimetype: string;
   belonging_to: number;  // id
   full_path: string;
-  file_url: string;
   thumbnail_url?: string;
 }
 

--- a/src/backend/cloudlatex/webAppApi.ts
+++ b/src/backend/cloudlatex/webAppApi.ts
@@ -104,7 +104,10 @@ export class CLWebAppApi {
   }
 
   async loadFiles(): Promise<unknown> {
-    const res = await fetch(`${this.apiProjects}/${this.config.projectId}/files`, this.fetchOption());
+    const res = await fetch(
+      `${this.apiProjects}/${this.config.projectId}/files`,
+      this.fetchOption()
+    );
     if (!res.ok) {
       throw new Error(await res.text());
     }
@@ -187,9 +190,10 @@ export class CLWebAppApi {
     return JSON.parse(await res.text());
   }
 
-  async download(url: string): Promise<NodeJS.ReadableStream> {
+  async downloadFile(fileId: number): Promise<NodeJS.ReadableStream> {
     const res = await fetch(
-      `${url}`
+      `${this.apiProjects}/${this.config.projectId}/files/${fileId}/download/`,
+      this.fetchOption()
     );
     if (!res.ok) {
       throw new Error(await res.text());
@@ -200,8 +204,13 @@ export class CLWebAppApi {
     return res.body;
   }
 
-  async downloadPreview(url: string): Promise<NodeJS.ReadableStream> {
-    const res = await fetch(url, this.fetchOption());
+  async download(url: string): Promise<NodeJS.ReadableStream> {
+    const res = await fetch(
+      `${url}`
+    );
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
     if (!res.body) {
       throw new Error('res.body is null');
     }

--- a/src/backend/cloudlatex/webAppApi.ts
+++ b/src/backend/cloudlatex/webAppApi.ts
@@ -192,7 +192,7 @@ export class CLWebAppApi {
 
   async downloadFile(fileId: number): Promise<NodeJS.ReadableStream> {
     const res = await fetch(
-      `${this.apiProjects}/${this.config.projectId}/files/${fileId}/download/`,
+      `${this.apiProjects}/${this.config.projectId}/files/${fileId}/download`,
       this.fetchOption()
     );
     if (!res.ok) {


### PR DESCRIPTION
## Summary

Changed to use /files/:id/download endpoint instead of file_url (S3 presigned URL).

## Background

In cloudlatex-team/cloudlatex2#9050, the web editor was updated to skip unnecessary file_url presigning. The plan is to eventually remove file_url dependency from all clients and remove the server-side implementation.

## Changes

- Add  downloadFile() method to use /files/:id/download endpoint
- Remove file_url field from ClFile  interface
- Update download() method to use remoteId instead of file_url
- Remove unused url module import
- Remove unused downloadPreview() method

## Impact

- CLI-plugin no longer depends on file_url
- File downloads now go through /files/:id/download endpoint
- Aligns with web client's file access pattern

## Testing

- [x] File synchronization works correctly
- [x] File downloads work correctly

## Related

- cloudlatex-team/cloudlatex2#9050