### PR TITLE
Actionsアップデート

### DIFF
--- a/.github/workflows/check-workflow.yml
+++ b/.github/workflows/check-workflow.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: reviewdog/action-actionlint@v1
         with:
           reporter: github-pr-review
-          fail_on_error: true
+          fail_level: any

--- a/.github/workflows/check-workflow.yml
+++ b/.github/workflows/check-workflow.yml
@@ -13,7 +13,7 @@ jobs:
   check-workflow:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: reviewdog/action-actionlint@v1
         with:
           reporter: github-pr-review

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup NodeJs
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '14.x'
         cache: yarn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup NodeJs
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
https://github.com/cloudlatex-team/cloudlatex-cli-plugin/actions/runs/23366340685/job/67980979184#step:15:2

```
Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

GitHub Actionsにおいて、Node.js 20が非推奨化されるので、Node.js 20を使っているActionsをNode.js 24に対応したバージョンへアップデートします。

https://github.com/reviewdog/action-actionlint/blob/d39025c0fb1cc41ac827852403ea94804b0e6907/action.yml#L36-L41

また、 `reviewdog/action-actionlint` では `fail_on_error` の代わりに `fail_level` を使うことが推奨されているので、そちらの置き換えも行っています。